### PR TITLE
refactor: update generateResponsive to use an array of variants instead of a string

### DIFF
--- a/packages/core/src/utils/generate-responsive-variants.ts
+++ b/packages/core/src/utils/generate-responsive-variants.ts
@@ -1,5 +1,5 @@
-export const generateResponsive = (variants: string[], breakpoints: string[]) => {
-  let classNames: string[] = [];
+export const generateResponsiveVariants = (variants: string[], breakpoints: string[]) => {
+  const classNames: string[] = [];
 
   variants.forEach((variant) => {
     breakpoints.forEach((breakpoint) => {

--- a/packages/core/src/utils/generateResponsive.ts
+++ b/packages/core/src/utils/generateResponsive.ts
@@ -1,13 +1,11 @@
-export const generateResponsive = (str: string, screens: string[]) => {
-    const strArray: string[] = str.split(" ")
+export const generateResponsive = (variants: string[], breakpoints: string[]) => {
+  let classNames: string[] = [];
 
-    let str_final: string[] = []
+  variants.forEach((variant) => {
+    breakpoints.forEach((breakpoint) => {
+        classNames.push(`${breakpoint}:${variant}`);
+    });
+  });
 
-    strArray.forEach((str, index) => {
-        screens.forEach(screen => {
-            str_final.push(`${screen}:${str}`)
-        })
-    })
-
-    return str_final
-}
+  return classNames;
+};

--- a/packages/core/src/utils/tailwind-utils.ts
+++ b/packages/core/src/utils/tailwind-utils.ts
@@ -33,5 +33,5 @@ export const generateSafeList = function (variantsArray: any[], screens: string[
     [
       ...Array.from(safelistClasses),
       ...Array.from(compoundClassesToTransform)
-    ].join(" "), screens)
+    ], screens)
 }

--- a/packages/core/src/utils/tailwind-utils.ts
+++ b/packages/core/src/utils/tailwind-utils.ts
@@ -1,4 +1,4 @@
-import { generateResponsive } from "./generateResponsive"
+import { generateResponsiveVariants } from "./generate-responsive-variants"
 
 export const generateSafeList = function (variantsArray: any[], screens: string[] = []) {
 
@@ -29,7 +29,7 @@ export const generateSafeList = function (variantsArray: any[], screens: string[
   })
 
   if (safelistClasses.size === 0) return []
-  return generateResponsive(
+  return generateResponsiveVariants(
     [
       ...Array.from(safelistClasses),
       ...Array.from(compoundClassesToTransform)


### PR DESCRIPTION
Simplify the way variants are passed to `generateResponsive`
