### PR TITLE
feat: restore v2 setupCompose + inferred VariantsProps compat over v3 core

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/packages/benchmark/benchmark.mjs
+++ b/packages/benchmark/benchmark.mjs
@@ -6,6 +6,7 @@ import * as CVA from "./configs/cva.mjs";
 import {
   noSlotsAndCompoundNoTwMergeNoResponsive,
   slotsAndCompoundNoTwMergeNoResponsive,
+  v2SetupComposeWithMerge,
 } from "./configs/tailwindbuddy.mjs";
 import * as TV from "./configs/tv.mjs";
 import { twMerge } from "./configs/twMerge.config.mjs";
@@ -37,6 +38,12 @@ suite
         size: "md",
       })
     );
+  })
+  // v2 setupCompose path: tailwind-merge injected internally (no external wrap)
+  .add("TAILWINDBUDDY v2 setupCompose - twMerge injected - compound yes", function () {
+    v2SetupComposeWithMerge.avatar.root({
+      size: "md",
+    });
   })
 
   .on("cycle", function (event) {

--- a/packages/benchmark/configs/tailwindbuddy.mjs
+++ b/packages/benchmark/configs/tailwindbuddy.mjs
@@ -1,4 +1,8 @@
-import { compose } from "@busbud/tailwind-buddy";
+import { compose, setupCompose } from "@busbud/tailwind-buddy";
+import { twMerge } from "tailwind-merge";
+
+// v2-style factory bound to tailwind-merge (mirrors a v2 consumer's setup).
+const composeV2 = setupCompose(["sm", "md", "lg", "xl", "2xl"], twMerge);
 
 export const options = {
   slots: {
@@ -56,4 +60,16 @@ export const slotsAndCompoundNoTwMergeNoResponsive = {
       label: "sr-only",
     },
   }),
+};
+
+// v2 `setupCompose` path: tailwind-merge injected internally (v2 consumer pattern).
+// Uses the v2 `class:` spelling to prove the compat path is exercised.
+export const v2SetupComposeWithMerge = {
+  avatar: composeV2({
+    ...options,
+    compoundVariants: [
+      { conditions: { size: "xs" }, class: { root: "ring-1" } },
+      { conditions: { size: "md" }, classes: "ring-2" },
+    ],
+  })(),
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,8 +21,9 @@
     "release": "pnpm prepack && changelogen --release --output ../../CHANGELOG.md  && pnpm publish --no-git-checks --access public && git push --follow-tags",
     "npm-auth-check": "[[ $(npm_config_registry=https://registry.npmjs.org npm whoami) = \"busbud-dev\" ]] && echo \"NPM Authentication ✅\"",
     "prepack": "pnpm build",
-    "test:ci": "CI=true pnpm test:unit",
-    "test:unit": "vitest"
+    "test:ci": "CI=true pnpm test:unit && pnpm typecheck:tests",
+    "test:unit": "vitest",
+    "typecheck:tests": "tsc --noEmit -p tsconfig.tests.json"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.19",

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,5 +1,11 @@
 export { generateSafeList } from "./utils/tailwind-utils";
-export { compose } from "./tailwind-buddy";
+export { compose, setupCompose } from "./tailwind-buddy";
+
+export type {
+  VariantsProps,
+  ComposeResult,
+  ComposeResultV2,
+} from "./tailwind-buddy";
 
 export type VariantProps<
   T extends Record<string, readonly string[]>,

--- a/packages/core/src/tailwind-buddy.ts
+++ b/packages/core/src/tailwind-buddy.ts
@@ -418,6 +418,8 @@ type NormalizedCompound<S extends Slots> = {
   classes: VariantValue<S>;
 };
 
+type EmptyVariants = Record<never, never>;
+
 type ComposeConfigNormalized<
   S extends Slots,
   V extends Variants<S>,
@@ -482,10 +484,10 @@ export const setupCompose = <Sc extends string>(
   mergeClasses: (input: string) => string = identityMerge
 ) => {
   return <
-    V extends Variants<S>,
-    CV extends CompoundVariant<V, S>,
-    DV extends DefaultVariants<V, S>,
     S extends Slots,
+    V extends Variants<S> = EmptyVariants,
+    CV extends CompoundVariant<V, S> = CompoundVariant<V, S>,
+    DV extends DefaultVariants<V, S> = DefaultVariants<V, S>,
     R extends ResponsiveVariants<V> = ResponsiveVariants<V>
   >(
     config: ComposeConfigInput<S, V, CV, R, DV>

--- a/packages/core/src/tailwind-buddy.ts
+++ b/packages/core/src/tailwind-buddy.ts
@@ -1,255 +1,533 @@
 import { cleanString } from "./utils/strings";
+import type { MergedProps } from "./types/props";
+import type {
+  CompoundVariant,
+  DefaultVariants,
+  ResponsiveVariants,
+  VariantValue,
+  Variants,
+} from "./types/variants";
+import type { Slots } from "./types/slots";
 
-const uniquifyClasses = (classes: string[]): string => {
-  return [...new Set(classes.filter(Boolean))].join(" ");
-};
+/* -------------------------------------------------------------------------- */
+/* Internal helpers                                                           */
+/* -------------------------------------------------------------------------- */
 
-const flattenVariant = (
-  variant: Record<string, string>,
-  slotKey: string
-): string[] => {
+const uniquifyClasses = (classes: string[]): string =>
+  [...new Set(classes.filter(Boolean))].join(" ");
+
+/** Type guard: narrows `unknown` to a string-keyed record (no unsafe cast). */
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+/**
+ * Extracts the classes for a single slot from a variant/compound value, which
+ * may be a string, an array of strings, or a per-slot map.
+ */
+const flattenVariant = (variant: unknown, slotKey: string): string[] => {
   if (typeof variant === "string") return [variant];
-  if (Array.isArray(variant)) return variant;
-  if (typeof variant === "object" && variant !== null) {
+  if (Array.isArray(variant)) {
+    return variant.filter((v): v is string => typeof v === "string");
+  }
+  if (isRecord(variant)) {
     const slotValue = variant[slotKey];
     if (typeof slotValue === "string") return [slotValue];
-    if (Array.isArray(slotValue)) return slotValue;
+    if (Array.isArray(slotValue)) {
+      return slotValue.filter((v): v is string => typeof v === "string");
+    }
   }
   return [];
 };
 
-type SlotFunction<Props extends Record<string, unknown>> = (opt?: Props) => string;
+/** No-op class merger used by the v3 `compose` entry point. */
+const identityMerge = (input: string): string => input;
 
-interface Alias {
-  slots: string[],
-  variants: Record<string, readonly string[]>
-  props: Record<string, any>;
-  screens: string[]
+/**
+ * Runtime shape every config is normalised to before the shared core runs.
+ * Kept intentionally loose: the strong typing is layered on by the public
+ * `compose` / `setupCompose` generics, not here. `slots` allows `string | string[]`
+ * so the v2 `Slots` type (which permits arrays) satisfies this constraint.
+ */
+interface ComposeConfigRuntime {
+  slots: Record<string, string | string[]>;
+  variants?: Record<string, Record<string, unknown>>;
+  compoundVariants?: ReadonlyArray<{
+    conditions: Record<string, unknown>;
+    classes: unknown;
+  }>;
+  defaultVariants?: Record<string, unknown>;
 }
 
-export const compose = <Def extends Alias>(options: {
-    slots: {
-      [K in Def['slots'][number]]: string
-    },
-    variants?: {
-      [K in keyof Def["variants"]]: {
-        [key in Def["variants"][K][number]] : {
-          [K in Def['slots'][number]]?: string
-        }  | string
-      }
-    },
-    compoundVariants?: {
-      conditions: Def['props'] | {
-        [K in keyof Def["variants"]]?: Def["variants"][K][number] | Def["variants"][K][number][];
-      },
-      classes: {
-        [K in Def['slots'][number]]?: string
-      } | string,
-    }[],
-    defaultVariants: {
-      [K in keyof Def["variants"]]?: Def["variants"][K][number];
-    },
-    responsiveVariants?: (keyof Def["variants"])[]
-}) => {
+/**
+ * Normalises compound variants so the shared core only ever reads `classes`.
+ * Accepts both the v2 `class` spelling and the v3 `classes` spelling, and
+ * preserves the precise `conditions` / class-value types for the caller.
+ */
+const normalizeCompoundVariants = <ClassValue, Conditions>(
+  compounds?: ReadonlyArray<{
+    conditions: Conditions;
+    class?: ClassValue;
+    classes?: ClassValue;
+  }>
+): { conditions: Conditions; classes: ClassValue }[] =>
+  (compounds ?? []).map((cv) => ({
+    conditions: cv.conditions,
+    // One of `class` / `classes` is guaranteed present by the public types.
+    classes: (cv.classes ?? cv.class) as ClassValue,
+  }));
 
-  const {
-        slots,
-        variants,
-        compoundVariants,
-        defaultVariants,
-  } = options
+/* -------------------------------------------------------------------------- */
+/* Shared core                                                                */
+/* -------------------------------------------------------------------------- */
 
+/**
+ * Builds the cached slot functions from a normalised config. This is the single
+ * runtime implementation shared by both `compose` (v3) and `setupCompose` (v2),
+ * so the hot path (cache lookup after the first call) is identical for both.
+ *
+ * `PropsType` carries the strongly-typed props bag so the returned slot
+ * functions are typed precisely without any value casts at the call site.
+ */
+const createSlotsCore = <
+  SlotNames extends string,
+  PropsType extends Record<string, unknown>,
+  Config extends ComposeConfigRuntime
+>(
+  config: Config,
+  mergeClasses: (input: string) => string
+): {
+  slots: Record<SlotNames, (props?: PropsType) => string>;
+  options: Config;
+} => {
+  const { slots, variants, compoundVariants, defaultVariants } = config;
+
+  // Flatten variants into a nested Map<variant, value, slot, Set<classes>>.
   const flattenedVariants = new Map<
     string,
     Map<string, Map<string, Set<string>>>
   >();
-    
   if (variants) {
-    Object.entries(variants).forEach(([variantKey, variantValues]) => {
+    for (const [variantKey, variantValues] of Object.entries(variants)) {
       const variantMap = new Map<string, Map<string, Set<string>>>();
-      Object.entries(variantValues).forEach(([valueKey, classes]) => {
+      for (const [valueKey, classes] of Object.entries(variantValues)) {
         const slotMap = new Map<string, Set<string>>();
-        Object.keys(slots).forEach((slotKey) => {
-          const slotClasses = flattenVariant(
-            // @ts-ignore
-            classes,
-            slotKey
-          );
-          slotMap.set(slotKey, new Set(slotClasses));
-        });
+        for (const slotKey of Object.keys(slots)) {
+          slotMap.set(slotKey, new Set(flattenVariant(classes, slotKey)));
+        }
         variantMap.set(valueKey, slotMap);
-      });
+      }
       flattenedVariants.set(variantKey, variantMap);
-    });
+    }
   }
 
-  const flattenedCompoundVariants =
-  compoundVariants?.map((cv) => ({
+  // Flatten compound variants once, keyed by slot.
+  const flattenedCompoundVariants = (compoundVariants ?? []).map((cv) => ({
     conditions: cv.conditions,
-    classes: new Map(
-      Object.entries(slots).map(([slotKey, _]) => [
+    classes: new Map<string, Set<string>>(
+      Object.keys(slots).map((slotKey) => [
         slotKey,
-        // @ts-ignore
         new Set(flattenVariant(cv.classes, slotKey)),
       ])
     ),
-  })) || [];
+  }));
 
   const variantCache = new Map<string, string>();
 
-  // @ts-ignore
-  const ret: Record<
-    Def['slots'][number],
-    SlotFunction<Def['props'] | { [K in keyof Def["variants"]]?: Def["variants"][K][number] | {
-      ["initial"]: Def["variants"][K][number]
-    } | {
-      [k in Def["screens"][number]]: Def["variants"][K][number]
-    }} | {
-      className?: string,
-      class?: string
-    }>
-  > = {}
-
-  Object.entries(slots).forEach((s) => {
-      const [slotKey, baseClasses] = s
-
-      ret[slotKey as Def['slots'][number]] = (props: Def['props'] | { [K in keyof Def["variants"]]?: Def["variants"][K][number] | {
-        ["initial"]: Def["variants"][K][number]
-      } | {
-        [k in Def["screens"][number]]: Def["variants"][K][number]
-      } | {
-        className?: string,
-        class?: string
-      }
-      } = {}) => {
-        const cleanedProps: Record<string, any> = {}
-
-        Object.keys(props).forEach(key => {
-          if (props[key]) {
-            cleanedProps[key] = props[key]
-          }
-        });
-
-        const cacheKey = JSON.stringify({ slot: slotKey, props: cleanedProps });
-
-        if (variantCache.has(cacheKey)) {
-          return variantCache.get(cacheKey) || "";
-        }
-
-        const classSet = new Set<string>();
-
-        classSet.add(cleanString(baseClasses as string));
-
-        // Merge default variants with props, giving precedence to props
-        const mergedProps = { ...defaultVariants, ...cleanedProps };
-
-
-        // Get all breakpoints used in props
-        const usedBreakpoints = new Set(["initial"]);
-        Object.values(mergedProps).forEach((value) => {
-          if (typeof value === "object" && value !== null) {
-            Object.keys(value).forEach((bp) => usedBreakpoints.add(bp));
-          }
-        });
-        // Apply variants (including overridden defaults)
-        Object.entries(mergedProps).forEach(([key, value]) => {
-          if (key !== "className" && key !== "class" && flattenedVariants.has(key)) {
-            if (typeof value === "object" && value !== null) {
-              // Handle responsive variants
-              Object.entries(value).forEach(
-                ([breakpoint, breakpointValue]) => {
-                  const variantClasses = flattenedVariants
-                    .get(key)
-                    ?.get(breakpointValue as string)
-                    ?.get(slotKey);
-                  if (variantClasses) {
-                    variantClasses.forEach((cls) => {
-                      if (breakpoint === "initial") {
-                        classSet.add(cleanString(cls));
-                      } else {
-                        const splitStr = cleanString(cls).split(" ");
-                        splitStr.forEach((c) => {
-                          classSet.add(`${breakpoint}:${c}`);
-                        });
-                      }
-                    });
-                  }
-                }
-              );
-            } else {
-              const variantClasses = flattenedVariants
-                .get(key)
-                ?.get(value as string)
-                ?.get(slotKey);
-              if (variantClasses) {
-                variantClasses.forEach((cls) => classSet.add(cls));
+  const slotsResult = Object.fromEntries(
+    Object.entries(slots).map(
+      ([slotKey, baseClasses]): [string, (props?: PropsType) => string] => {
+        const slotFunction = (props?: PropsType): string => {
+          const cleanedProps: Record<string, unknown> = {};
+          if (props !== undefined) {
+            for (const key of Object.keys(props)) {
+              const value = props[key];
+              if (value !== undefined && value !== null) {
+                cleanedProps[key] = value;
               }
             }
           }
-        });
 
-        // Apply compound variants
-        flattenedCompoundVariants.forEach(({ conditions, classes }) => {
-          usedBreakpoints.forEach((breakpoint) => {
-            let isMatch = true;
-            Object.entries(conditions).forEach(([key, conditionValue]) => {
-              const propValue = mergedProps[key];
-              let valueToCheck: unknown;
-              if (typeof propValue === "object" && propValue !== null) {
-                // Handle responsive variant
-                valueToCheck =
-                  breakpoint === "initial"
-                    ? (propValue as { initial: unknown }).initial
-                    : (propValue as Record<string, unknown>)[breakpoint] ||
-                      (propValue as { initial: unknown }).initial;
-              } else {
-                valueToCheck = propValue;
+          const cacheKey = JSON.stringify({ slot: slotKey, props: cleanedProps });
+          if (variantCache.has(cacheKey)) {
+            return variantCache.get(cacheKey) ?? "";
+          }
+
+          const classSet = new Set<string>();
+          const base = Array.isArray(baseClasses)
+            ? baseClasses.join(" ")
+            : baseClasses;
+          classSet.add(cleanString(base));
+
+          // Defaults first, props override.
+          const mergedProps: Record<string, unknown> = {
+            ...defaultVariants,
+            ...cleanedProps,
+          };
+
+          // Collect every breakpoint referenced by responsive props.
+          const usedBreakpoints = new Set<string>(["initial"]);
+          for (const value of Object.values(mergedProps)) {
+            if (isRecord(value)) {
+              for (const bp of Object.keys(value)) {
+                usedBreakpoints.add(bp);
               }
+            }
+          }
 
-              isMatch =
-                isMatch &&
-                (Array.isArray(conditionValue)
-                  ? (conditionValue as Array<unknown>).includes(
-                      valueToCheck
-                    )
-                  : conditionValue === valueToCheck);
-            });
-            if (isMatch) {
-              classes.get(slotKey)?.forEach((cls) => {
+          // Apply variants (including responsive overrides).
+          for (const [key, value] of Object.entries(mergedProps)) {
+            if (key === "className" || key === "class") continue;
+            const variantMap = flattenedVariants.get(key);
+            if (!variantMap) continue;
+
+            if (isRecord(value)) {
+              for (const [breakpoint, breakpointValue] of Object.entries(value)) {
+                const variantClasses = variantMap
+                  .get(breakpointValue as string)
+                  ?.get(slotKey);
+                if (!variantClasses) continue;
+                for (const cls of variantClasses) {
+                  if (breakpoint === "initial") {
+                    classSet.add(cleanString(cls));
+                  } else {
+                    for (const c of cleanString(cls).split(" ")) {
+                      classSet.add(`${breakpoint}:${c}`);
+                    }
+                  }
+                }
+              }
+            } else {
+              const variantClasses = variantMap
+                .get(value as string)
+                ?.get(slotKey);
+              if (!variantClasses) continue;
+              for (const cls of variantClasses) {
+                classSet.add(cls);
+              }
+            }
+          }
+
+          // Apply compound variants across every used breakpoint.
+          for (const { conditions, classes } of flattenedCompoundVariants) {
+            for (const breakpoint of usedBreakpoints) {
+              let isMatch = true;
+              for (const [key, conditionValue] of Object.entries(conditions)) {
+                const propValue = mergedProps[key];
+                let valueToCheck: unknown;
+                if (isRecord(propValue)) {
+                  valueToCheck =
+                    breakpoint === "initial"
+                      ? propValue["initial"]
+                      : (propValue[breakpoint] ?? propValue["initial"]);
+                } else {
+                  valueToCheck = propValue;
+                }
+                isMatch =
+                  isMatch &&
+                  (Array.isArray(conditionValue)
+                    ? conditionValue.includes(valueToCheck)
+                    : conditionValue === valueToCheck);
+                if (!isMatch) break;
+              }
+              if (!isMatch) continue;
+
+              const slotClasses = classes.get(slotKey);
+              if (!slotClasses) continue;
+              for (const cls of slotClasses) {
                 if (breakpoint === "initial") {
                   classSet.add(cleanString(cls));
                 } else {
-                  const splitStr = cleanString(cls).split(" ");
-                  splitStr.forEach((c) => {
+                  for (const c of cleanString(cls).split(" ")) {
                     classSet.add(`${breakpoint}:${c}`);
-                  });
+                  }
                 }
-              });
+              }
             }
-          });
-        });
+          }
 
-        // Add custom className if provided
-        if (cleanedProps?.className) {
-          cleanString(cleanedProps.className)
-            .split(" ")
-            .forEach((cls) => classSet.add(cls));
-        }
+          // Custom className/class overrides.
+          const customClassName = cleanedProps["className"];
+          if (typeof customClassName === "string") {
+            for (const cls of cleanString(customClassName).split(" ")) {
+              classSet.add(cls);
+            }
+          }
+          const customClass = cleanedProps["class"];
+          if (typeof customClass === "string") {
+            for (const cls of cleanString(customClass).split(" ")) {
+              classSet.add(cls);
+            }
+          }
 
-        if (cleanedProps?.class) {
-          cleanString(cleanedProps.class)
-            .split(" ")
-            .forEach((cls) => classSet.add(cls));
-        }
-
-        const result = uniquifyClasses(Array.from(classSet));
-        variantCache.set(cacheKey, result);
-        return result;
+          const result = mergeClasses(uniquifyClasses(Array.from(classSet)));
+          variantCache.set(cacheKey, result);
+          return result;
+        };
+        return [slotKey, slotFunction];
       }
-  })
+    )
+  );
 
   return {
-    slots: ret,
-    options
-  }
+    slots: slotsResult as Record<SlotNames, (props?: PropsType) => string>,
+    options: config,
+  };
+};
+
+/* -------------------------------------------------------------------------- */
+/* v3 entry point: `compose`                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Shape declared explicitly (the `ComposeType` the v3 consumer writes).
+ *
+ * `props` is `unknown` (not `Record<string, any>`): a consumer's concrete
+ * interface (e.g. `LabelBaseProps`, which has no string index signature) does
+ * not satisfy `Record<string, unknown>`, so the constraint must not require
+ * one. Instead the index signature the core relies on is added at the two
+ * surfaces `Def["props"]` flows into — `ComposeSlotProps` and the compound
+ * `conditions` — via `& Record<string, unknown>`. There, a concrete key wins
+ * over the index signature so call-site props stay precise, while undeclared
+ * extras (e.g. `disabled` on a `props: {}` component) stay accepted, matching
+ * the original v3 behaviour. No `any` and no consumer changes.
+ */
+interface Alias {
+  slots: string[];
+  variants: Record<string, readonly string[]>;
+  props: unknown;
+  screens: string[];
 }
+
+type ComposeClassValue<Def extends Alias> =
+  | { [K in Def["slots"][number]]?: string }
+  | string;
+
+/** Compound variant accepted by `compose` — `class` and `classes` both work. */
+type ComposeCompoundVariant<Def extends Alias> = {
+  conditions: (
+    | Def["props"]
+    | {
+        [K in keyof Def["variants"]]?: Def["variants"][K][number] | Def["variants"][K][number][];
+      }
+  ) &
+    Record<string, unknown>;
+} & (
+  | { class: ComposeClassValue<Def>; classes?: undefined }
+  | { classes: ComposeClassValue<Def>; class?: undefined }
+);
+
+/** Options accepted by `compose`. */
+type ComposeOptions<Def extends Alias> = {
+  slots: { [K in Def["slots"][number]]: string };
+  variants?: {
+    [K in keyof Def["variants"]]: {
+      [key in Def["variants"][K][number]]: { [S in Def["slots"][number]]?: string } | string;
+    };
+  };
+  compoundVariants?: ComposeCompoundVariant<Def>[];
+  defaultVariants: { [K in keyof Def["variants"]]?: Def["variants"][K][number] };
+  responsiveVariants?: (keyof Def["variants"])[];
+};
+
+/**
+ * The props bag a v3 slot function accepts. An intersection (not a union) so
+ * variants, component props and `className`/`class` can all be passed together.
+ * `Def["props"]` is `unknown` in `Alias`; the explicit `& Record<string,
+ * unknown>` here provides the string index signature the shared core relies on
+ * (and which lets `props: {}` accept arbitrary extras such as `disabled`)
+ * regardless of whether the consumer's `props` is a concrete interface or a
+ * record type. Specific declared keys win over the index signature, so
+ * call-site props stay precise. This only affects the v3 slot function params
+ * — v3 `VariantProps` is derived independently from `ComposeType["variants"]`,
+ * and the v2 `MergedProps` carries no such signature so `VariantsProps<typeof
+ * x>` stays precise.
+ */
+type ComposeSlotProps<Def extends Alias> = Def["props"] & {
+  [K in keyof Def["variants"]]?:
+    | Def["variants"][K][number]
+    | { initial: Def["variants"][K][number] }
+    | { [S in Def["screens"][number]]?: Def["variants"][K][number] };
+} & {
+  className?: string;
+  class?: string;
+} & Record<string, unknown>;
+
+/**
+ * `ComposeOptions` after `class` -> `classes` normalisation. The
+ * `compoundVariants` always carry `classes`, which is what the shared core (and
+ * `generateSafeList`) read. This precise shape lets the core's `Config`
+ * constraint hold without any cast, while `options` is still assignable to the
+ * public `ComposeOptions`.
+ */
+type ComposeOptionsNormalized<Def extends Alias> = Omit<
+  ComposeOptions<Def>,
+  "compoundVariants"
+> & {
+  compoundVariants: {
+    conditions: ComposeCompoundVariant<Def>["conditions"];
+    classes: ComposeClassValue<Def>;
+  }[];
+};
+
+export type ComposeResult<Def extends Alias> = {
+  slots: Record<Def["slots"][number], (props?: ComposeSlotProps<Def>) => string>;
+  options: ComposeOptions<Def>;
+};
+
+/**
+ * v3 public entry point. Slots are exposed under `.slots` and the (normalised)
+ * input is returned as `.options` for `generateSafeList`.
+ */
+export const compose = <Def extends Alias>(
+  options: ComposeOptions<Def>
+): ComposeResult<Def> => {
+  const normalized: ComposeOptionsNormalized<Def> = {
+    ...options,
+    compoundVariants: normalizeCompoundVariants(options.compoundVariants),
+  };
+  const core = createSlotsCore<
+    Def["slots"][number],
+    ComposeSlotProps<Def>,
+    ComposeOptionsNormalized<Def>
+  >(normalized, identityMerge);
+  return { slots: core.slots, options: core.options };
+};
+
+/* -------------------------------------------------------------------------- */
+/* v2 entry point: `setupCompose`                                             */
+/* -------------------------------------------------------------------------- */
+
+type ComposeConfigInput<
+  S extends Slots,
+  V extends Variants<S>,
+  CV extends CompoundVariant<V, S>,
+  R extends ResponsiveVariants<V>,
+  DV extends DefaultVariants<V, S>
+> = {
+  slots: S;
+  variants?: V;
+  compoundVariants?: CV[];
+  responsiveVariants?: R;
+  // Required so `.definition().defaultVariants.<key>` stays non-optional, matching v2.
+  defaultVariants: DV;
+};
+
+/** Compound variant after `class` -> `classes` normalisation (v2 output shape). */
+type NormalizedCompound<S extends Slots> = {
+  conditions: Record<string, unknown>;
+  classes: VariantValue<S>;
+};
+
+type ComposeConfigNormalized<
+  S extends Slots,
+  V extends Variants<S>,
+  R extends ResponsiveVariants<V>,
+  DV extends DefaultVariants<V, S>
+> = {
+  slots: S;
+  variants?: V;
+  compoundVariants: NormalizedCompound<S>[];
+  responsiveVariants?: R;
+  defaultVariants: DV;
+};
+
+type DefinitionResult<
+  S extends Slots,
+  V extends Variants<S>,
+  R extends ResponsiveVariants<V>,
+  DV extends DefaultVariants<V, S>,
+  Sc extends string
+> = {
+  slots: S;
+  variants?: V;
+  compoundVariants: NormalizedCompound<S>[];
+  responsiveVariants?: R;
+  defaultVariants: DV;
+  screens: readonly Sc[];
+};
+
+/**
+ * The full return of a v2 `setupCompose(...)(config)<Props>()` call.
+ *
+ * Slot functions live at the top level (so `const { root } = variants` works),
+ * `definition()` exposes the config for introspection / storybook iteration,
+ * and `options` carries the normalised config consumed by `generateSafeList`.
+ */
+export type ComposeResultV2<
+  S extends Slots,
+  V extends Variants<S>,
+  R extends ResponsiveVariants<V>,
+  DV extends DefaultVariants<V, S>,
+  Sc extends string,
+  Props
+> = {
+  [Slot in keyof S & string]: (props?: MergedProps<Props, Sc, V, R>) => string;
+} & {
+  definition: () => DefinitionResult<S, V, R, DV, Sc>;
+  options: ComposeConfigNormalized<S, V, R, DV>;
+};
+
+/**
+ * Factory matching the v2 signature: binds `screens` and a `mergeClasses`
+ * (e.g. tailwind-merge) function, then returns the curried composer.
+ *
+ * The curry mirrors v2 exactly: `setupCompose(screens, mergeClasses)` ->
+ * `(config) => <Props>() => result`, so existing v2 call sites compile
+ * unchanged. `defaultVariants` is required (v2 behaviour); `responsiveVariants`
+ * defaults to treating every variant as scalar, and a component may omit
+ * `variants` / `compoundVariants` entirely (issue #31).
+ */
+export const setupCompose = <Sc extends string>(
+  screens: readonly Sc[],
+  mergeClasses: (input: string) => string = identityMerge
+) => {
+  return <
+    V extends Variants<S>,
+    CV extends CompoundVariant<V, S>,
+    DV extends DefaultVariants<V, S>,
+    S extends Slots,
+    R extends ResponsiveVariants<V> = ResponsiveVariants<V>
+  >(
+    config: ComposeConfigInput<S, V, CV, R, DV>
+  ) => {
+    const normalized = {
+      ...config,
+      compoundVariants: normalizeCompoundVariants(config.compoundVariants),
+    };
+
+    return <Props = unknown>(): ComposeResultV2<S, V, R, DV, Sc, Props> => {
+      const core = createSlotsCore<
+        keyof S & string,
+        MergedProps<Props, Sc, V, R>,
+        ComposeConfigNormalized<S, V, R, DV>
+      >(normalized, mergeClasses);
+
+      const definition = (): DefinitionResult<S, V, R, DV, Sc> => ({
+        ...normalized,
+        screens,
+      });
+
+      return {
+        ...core.slots,
+        definition,
+        options: core.options,
+      };
+    };
+  };
+};
+
+/* -------------------------------------------------------------------------- */
+/* Inferred variant props (v2)                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Infers the props bag of a composed component from its slot functions.
+ *
+ * Works against the v2 `setupCompose` result (which carries slot functions plus
+ * a `definition` / `options` member): `Extract` keeps only the function members,
+ * so `VariantsProps<typeof buttonVariants>` yields the merged props without
+ * requiring the consumer to re-declare the variant keys (resolves issue #31).
+ */
+export type VariantsProps<C extends Record<string, unknown>> = Parameters<
+  Extract<C[keyof C], (...args: any[]) => unknown>
+>[0];

--- a/packages/core/src/tailwind-buddy.ts
+++ b/packages/core/src/tailwind-buddy.ts
@@ -526,10 +526,15 @@ export const setupCompose = <Sc extends string>(
  * Infers the props bag of a composed component from its slot functions.
  *
  * Works against the v2 `setupCompose` result (which carries slot functions plus
- * a `definition` / `options` member): `Extract` keeps only the function members,
- * so `VariantsProps<typeof buttonVariants>` yields the merged props without
+ * a `definition` / `options` member). Slot functions are the only members that
+ * return `string`; `Extract`ing by that return type keeps them and drops
+ * `definition` (returns an object) and `options` (not callable). Extracting on
+ * `(...args: any[]) => unknown` instead would also match `definition`, widening
+ * the result to `Parameters<slot> | Parameters<definition>` — i.e. the slot bag
+ * `| undefined`. Selecting on the `string` return type yields exactly the slot
+ * bag, so `VariantsProps<typeof buttonVariants>` gives the merged props without
  * requiring the consumer to re-declare the variant keys (resolves issue #31).
  */
 export type VariantsProps<C extends Record<string, unknown>> = Parameters<
-  Extract<C[keyof C], (...args: any[]) => unknown>
+  Extract<C[keyof C], (...args: any[]) => string>
 >[0];

--- a/packages/core/src/tailwind-buddy.ts
+++ b/packages/core/src/tailwind-buddy.ts
@@ -164,9 +164,13 @@ const createSlotsCore = <
             ...cleanedProps,
           };
 
-          // Collect every breakpoint referenced by responsive props.
+          // Collect every breakpoint referenced by responsive *variant* props.
+          // Only declared variants may carry responsive objects; iterating other
+          // object-valued props (e.g. a `style`/`sx` bag) would leak their keys
+          // as breakpoints and emit garbage `<key>:`-prefixed compound classes.
           const usedBreakpoints = new Set<string>(["initial"]);
-          for (const value of Object.values(mergedProps)) {
+          for (const [key, value] of Object.entries(mergedProps)) {
+            if (!flattenedVariants.has(key)) continue;
             if (isRecord(value)) {
               for (const bp of Object.keys(value)) {
                 usedBreakpoints.add(bp);

--- a/packages/core/src/types/props.ts
+++ b/packages/core/src/types/props.ts
@@ -1,0 +1,32 @@
+import type { ResponsiveVariant, ResponsiveVariants } from "./variants";
+
+/**
+ * The full props bag accepted by a slot function produced via `setupCompose`.
+ *
+ * It merges:
+ * - `className` / `class` overrides,
+ * - every declared variant (optionally responsive when listed in `R`),
+ * - the consumer's own component props (`Props`),
+ * - a string index signature so the runtime can iterate props generically.
+ *
+ * No explicit index signature is added: an all-optional-key intersection is
+ * still assignable to `Record<string, unknown>` (so the shared core, which
+ * constrains its props generic to `Record<string, unknown>`, can index it),
+ * while specific variant keys keep their inferred literal unions for
+ * `VariantsProps<typeof x>` consumers — matching the v2 behaviour exactly.
+ */
+export type MergedProps<
+  Props,
+  Sc extends string,
+  V,
+  R extends ResponsiveVariants<V> = ResponsiveVariants<V>
+> = {
+  className?: string;
+  class?: string;
+} & {
+  [K in keyof V]?: K extends R[number]
+    ? ResponsiveVariant<V, Sc, K> | keyof V[K]
+    : keyof V[K];
+} & {
+  [K in keyof Props]?: Props[K];
+};

--- a/packages/core/src/types/slots.ts
+++ b/packages/core/src/types/slots.ts
@@ -1,0 +1,11 @@
+/**
+ * A map of slot names to their base classes.
+ *
+ * `root` is required (every component has a root slot); any other slots are
+ * declared by the consumer. The string-index signature lets variant values
+ * target arbitrary slots without having to enumerate them.
+ */
+export type Slots = {
+  [slot: string]: string | string[];
+  root: string | string[];
+};

--- a/packages/core/src/types/variants.ts
+++ b/packages/core/src/types/variants.ts
@@ -3,8 +3,12 @@ import type { Slots } from "./slots";
 /**
  * The set of variant names that may receive responsive (`{ initial, ...screens }`) values.
  *
- * Defaults to `never[]` so that, when `responsiveVariants` is omitted, every
- * variant is treated as a plain scalar (resolves issue #31 — optionality).
+ * When the `responsiveVariants` generic is not supplied, it defaults to this
+ * type (`(keyof V)[]`), so `MergedProps` type-accepts a responsive object for
+ * every variant. That is intentionally permissive: the runtime accepts both a
+ * scalar and a responsive object regardless of what `responsiveVariants` lists,
+ * so widening the type never produces an invalid config. `responsiveVariants`
+ * itself stays optional (resolves issue #31 — optionality).
  */
 export type ResponsiveVariants<V> = (keyof V)[];
 

--- a/packages/core/src/types/variants.ts
+++ b/packages/core/src/types/variants.ts
@@ -1,0 +1,63 @@
+import type { Slots } from "./slots";
+
+/**
+ * The set of variant names that may receive responsive (`{ initial, ...screens }`) values.
+ *
+ * Defaults to `never[]` so that, when `responsiveVariants` is omitted, every
+ * variant is treated as a plain scalar (resolves issue #31 — optionality).
+ */
+export type ResponsiveVariants<V> = (keyof V)[];
+
+/**
+ * A variant definition inferred from the `variants` object literal.
+ *
+ * Each variant maps its keys (e.g. `"primary"`, `"secondary"`) to either a
+ * shared class string/array or a per-slot map `{ [slot]: classes }`.
+ */
+export type Variants<S extends Slots> = {
+  [variant: string]: {
+    [kind: string]: string | string[] | { [key in keyof S]?: string | string[] };
+  };
+};
+
+/**
+ * Optional defaults for each variant. Made optional (issue #31) so consumers
+ * are not forced to specify a value for every variant.
+ */
+export type DefaultVariants<V extends Variants<S>, S extends Slots> = {
+  [K in keyof V]?: keyof V[K];
+};
+
+/**
+ * The class payload a single variant key (or compound variant) may carry.
+ */
+export type VariantValue<S extends Slots> =
+  | string
+  | string[]
+  | { [key in keyof S]?: string | string[] };
+
+/**
+ * A compound variant. Both `class` (v2 spelling) and `classes` (v3 spelling)
+ * are accepted as an alias so existing v2 configs compile unchanged while new
+ * configs may use either.
+ *
+ * `conditions` accepts the declared variant keys (with literal/array values or
+ * booleans) plus an arbitrary string index so ad-hoc props such as
+ * `isDisabled: true` can be matched without being declared as variants.
+ */
+export type CompoundVariant<V extends Variants<S>, S extends Slots> = {
+  conditions: {
+    [K in keyof V]?: (keyof V[K]) | (keyof V[K])[] | boolean;
+  } & { [K in string]?: string | string[] | boolean };
+} & (
+  | { class: VariantValue<S>; classes?: undefined }
+  | { classes: VariantValue<S>; class?: undefined }
+);
+
+/**
+ * A responsive value for variant `K`: an `initial` key plus optional per-screen
+ * overrides.
+ */
+export type ResponsiveVariant<V, Sc extends string, K extends keyof V> = {
+  initial: keyof V[K];
+} & { [screen in Sc]?: keyof V[K] };

--- a/packages/core/src/utils/tailwind-utils.ts
+++ b/packages/core/src/utils/tailwind-utils.ts
@@ -1,106 +1,93 @@
 import { generateResponsiveVariants } from "./generate-responsive-variants";
 import { cleanString } from "./strings";
 
-function cleanVariantsClasses(variants: {
-  [k in string]: {
-    [k in string]: string
-  } | {
-    [k in string]: string
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const cleanClassPayload = (value: unknown): unknown => {
+  if (typeof value === "string") {
+    return cleanString(value);
   }
-}) {
-  const _variants = variants
-  Object.entries(_variants).forEach(([vKey, vValue]) => {
-    Object.entries(vValue).forEach(([key, value]) => {
-      if (typeof value === "string") {
-        _variants[vKey][key] = cleanString(value);
-      } else if (typeof value === "object") {
-        Object.entries(value).forEach(([rKey, values]) => {
-          // @ts-ignore
-          _variants[vKey][key][rKey] = cleanString(values);
-        });
-      } else {
-        console.log("cleanVariantsClasses: type missmatch on safeList");
-      }
+
+  if (Array.isArray(value)) {
+    return value
+      .filter((className): className is string => typeof className === "string")
+      .map(cleanString);
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, classValue]) => [
+        key,
+        cleanClassPayload(classValue),
+      ])
+    );
+  }
+
+  return value;
+};
+
+const addClassTokens = (value: unknown, safelistClasses: Set<string>) => {
+  if (typeof value === "string") {
+    cleanString(value)
+      .split(" ")
+      .filter(Boolean)
+      .forEach((className) => {
+        safelistClasses.add(className);
+      });
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((classValue) => {
+      addClassTokens(classValue, safelistClasses);
+    });
+    return;
+  }
+
+  if (isRecord(value)) {
+    Object.values(value).forEach((classValue) => {
+      addClassTokens(classValue, safelistClasses);
+    });
+  }
+};
+
+function cleanVariantsClasses<
+  T extends Record<string, Record<string, unknown>> | undefined
+>(variants: T): T {
+  if (!variants) return variants;
+
+  Object.values(variants).forEach((variantValues) => {
+    Object.entries(variantValues).forEach(([key, value]) => {
+      variantValues[key] = cleanClassPayload(value);
     });
   });
 
-  return _variants
+  return variants;
 }
 
 function cleanCompoundClasses(
   compoundClasses: {
-    conditions: any[];
-    classes: string | string[] | { [key: string]: string | string[] };
+    conditions: unknown;
+    class?: unknown;
+    classes?: unknown;
   }[]
 ) {
   return compoundClasses.map((compound) => {
-    const { conditions, classes: c } = compound;
-    if (Array.isArray(c)) {
-      const ret: string[] = [];
-      c.forEach((v) => {
-        ret.push(cleanString(v));
-      });
-      return { conditions, class: ret };
-    } else if (typeof c === "string") {
-      return { conditions, class: cleanString(c) };
-    } else if (typeof c === "object") {
-      const ret: { [key: string]: string | string[] } = {};
-      Object.entries(c).forEach(([rKey, values]) => {
-        if (Array.isArray(values)) {
-          const retValues: string[] = [];
-          values.forEach((v) => {
-            retValues.push(cleanString(v));
-          });
-          ret[rKey] = retValues;
-        } else {
-          ret[rKey] = cleanString(values);
-        }
-      });
-      return { conditions, class: ret };
-    } else {
-      console.log("cleanCompoundClasses: type missmatch on safeList");
-    }
+    const { conditions } = compound;
+    const classValue =
+      compound.classes !== undefined ? compound.classes : compound.class;
+
+    return { conditions, class: cleanClassPayload(classValue) };
   });
 }
 
 function extractVariantClasses(variant: any, safelistClasses: Set<string>) {
-  Object.entries(variant).forEach(([_, values]: any) => {
-    if (typeof values === "string") {
-      const splitValues = values.split(" ");
-      splitValues.forEach((values: any) => {
-        safelistClasses.add(values);
-      });
-    } else if (typeof values === "object") {
-      Object.entries(values).forEach(([_, values]: any) => {
-        const splitValues = values.split(" ");
-        splitValues.forEach((values: any) => {
-          safelistClasses.add(values);
-        });
-      });
-    } else {
-      console.log("extractVariantClasses: type missmatch on safeList");
-    }
-  });
+  addClassTokens(variant, safelistClasses);
 }
 
 function extractCompoundClasses(compound: any, safelistClasses: Set<string>) {
-  const c = compound.class;
-   if (typeof c === "string") {
-    const splitValues = c.split(" ");
-    splitValues.forEach((values: any) => {
-      safelistClasses.add(values);
-    });
-  } else if (typeof c === "object") {
-    Object.entries(c).forEach(([_, values]: any) => {
-      const splitValues = values.split(" ");
-      splitValues.forEach((values: any) => {
-        safelistClasses.add(values);
-      });
-    });
-  } else {
-    // @ts-ignore
-    console.log("extractCompoundClasses: type missmatch on safeList for variants");
-  }
+  addClassTokens(compound.class, safelistClasses);
 }
 
 export const generateSafeList = function (variantsArray: any[], screens = ["sm", "md", "lg", "xl", "xxl"]) {

--- a/packages/core/src/utils/tailwind-utils.ts
+++ b/packages/core/src/utils/tailwind-utils.ts
@@ -105,7 +105,10 @@ export const generateSafeList = function (variantsArray: any[], screens = ["sm",
       const compounds = definitionResult.compoundVariants || [];
       definitionResult.responsiveVariants.forEach((variant: any) => {
         extractVariantClasses(
-          definitionResult.variants[variant],
+          // `variants` is optional for v2 consumers; a component may declare
+          // `responsiveVariants` without a `variants` map. Guard the access so
+          // it does not throw (extractVariantClasses no-ops on undefined).
+          definitionResult.variants?.[variant],
           safelistClasses
         );
         const compoundFounds = compounds.filter((compound: any) => {

--- a/packages/core/tests/configs/v2-compat.test.ts
+++ b/packages/core/tests/configs/v2-compat.test.ts
@@ -133,4 +133,26 @@ describe("v2 compat: setupCompose", () => {
     } as Record<string, unknown>);
     expect(loose).not.toContain("null");
   });
+
+  it("does not treat object-valued non-variant props as breakpoints", () => {
+    // Regression: an object-valued prop that is NOT a declared variant (e.g. a
+    // `style`/`sx` object) had its keys leaked into `usedBreakpoints`, so a
+    // matching compound emitted garbage `<key>:`-prefixed classes.
+    const compose2 = setupCompose(["sm", "lg"] as const);
+    const variants = compose2({
+      slots: { root: "block" },
+      variants: { intent: { primary: { root: "text-blue-500" } } },
+      compoundVariants: [
+        { conditions: { intent: "primary" }, class: { root: "font-bold" } },
+      ],
+      defaultVariants: { intent: "primary" },
+    })<{ style?: Record<string, unknown> }>();
+
+    const root = variants.root({ style: { color: "red" } });
+    // compound applies unprefixed…
+    expect(root).toContain("font-bold");
+    // …but the non-variant object's key must NOT become a breakpoint prefix.
+    expect(root).not.toContain("color:font-bold");
+    expect(root).not.toContain("color:");
+  });
 });

--- a/packages/core/tests/configs/v2-compat.test.ts
+++ b/packages/core/tests/configs/v2-compat.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import { setupCompose } from "../../src/tailwind-buddy";
+import {
+  buttonVariants,
+  mergeClasses as consumerMerge,
+  screens,
+} from "../setup/v2-compat";
+
+describe("v2 compat: setupCompose", () => {
+  it("exposes slot functions at the top level (v2 destructuring)", () => {
+    // `const { root } = buttonVariants` — v2 access pattern.
+    expect(typeof buttonVariants.root).toBe("function");
+    expect(typeof buttonVariants.label).toBe("function");
+    expect(typeof buttonVariants.icon).toBe("function");
+  });
+
+  it("exposes definition() with defaultVariants for introspection", () => {
+    const def = buttonVariants.definition();
+    expect(def.defaultVariants.appearance).toBe("default");
+    expect(def.defaultVariants.size).toBe("md");
+    expect(def.defaultVariants.variant).toBe("contained");
+    expect(def.screens).toEqual(screens);
+  });
+
+  it("applies default variants", () => {
+    const root = buttonVariants.root();
+    // base + size:md (p-3) + variant:contained + appearance:default
+    expect(root).toContain("inline-flex");
+    expect(root).toContain("p-3"); // size md
+  });
+
+  it("applies `class:` (singular) compound variants — the v3 silent-break fix", () => {
+    // On unpatched v3, `class:` compounds are silently ignored (cv.classes is
+    // undefined). This guards against that regression.
+    const root = buttonVariants.root({
+      appearance: "primary",
+      variant: "contained",
+      isDisabled: false,
+      isDisabledFocusable: false,
+    });
+    expect(root).toContain("hover:bg-blue-600");
+
+    const icon = buttonVariants.icon({
+      appearance: "primary",
+      variant: "contained",
+      isDisabled: false,
+      isDisabledFocusable: false,
+    });
+    expect(icon).toContain("group-hover:text-blue-200");
+  });
+
+  it("also accepts `classes:` (plural) compound variants", () => {
+    const root = buttonVariants.root({
+      appearance: "destructive",
+      variant: "contained",
+      isDisabled: false,
+      isDisabledFocusable: false,
+    });
+    expect(root).toContain("hover:bg-red-600");
+  });
+
+  it("applies disabled compound via class:", () => {
+    const root = buttonVariants.root({
+      variant: "contained",
+      isDisabled: true,
+    });
+    expect(root).toContain("bg-gray-300");
+    expect(root).toContain("text-gray-400");
+  });
+
+  it("supports responsive variants", () => {
+    const root = buttonVariants.root({
+      size: { initial: "sm", lg: "lg" },
+    });
+    // initial -> p-2 (sm), lg breakpoint -> lg:p-4 (lg)
+    expect(root).toContain("p-2");
+    expect(root).toContain("lg:p-4");
+  });
+
+  it("merges custom className", () => {
+    const root = buttonVariants.root({ className: "custom-class" });
+    expect(root).toContain("custom-class");
+  });
+
+  it("options is present for generateSafeList", () => {
+    expect(buttonVariants.options).toBeDefined();
+    expect(buttonVariants.options.slots).toBeDefined();
+  });
+
+  it("mergeClasses resolves conflicting utilities (tailwind-merge behaviour)", () => {
+    // base `p-1` overridden by size:lg `p-4` — mergeClasses keeps the last.
+    const compose2 = setupCompose(["md", "lg"] as const, consumerMerge);
+    const variants = compose2({
+      slots: { root: "p-1" },
+      variants: { size: { sm: { root: "p-2" }, lg: { root: "p-4" } } },
+      defaultVariants: { size: "sm" },
+    })();
+    const root = variants.root({ size: "lg" });
+    expect(root).toContain("p-4");
+    expect(root).not.toContain("p-1");
+    expect(root).not.toContain("p-2");
+  });
+
+  it("invokes mergeClasses on a cache miss and serves cache hits (perf parity)", () => {
+    const spy = vi.fn((s: string) => consumerMerge(s));
+    const compose2 = setupCompose(["md"] as const, spy);
+    const variants = compose2({
+      slots: { root: "p-1" },
+      variants: { size: { sm: { root: "p-2" }, lg: { root: "p-4" } } },
+      defaultVariants: { size: "sm" },
+    })();
+
+    // cache miss: mergeClasses runs exactly once and resolves the conflict.
+    const first = variants.root({ size: "lg" });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(first).toContain("p-4");
+
+    // cache hit: mergeClasses must NOT run again.
+    const second = variants.root({ size: "lg" });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+
+  it("treats undefined props as absent (no 'undefined' class leak)", () => {
+    const root = buttonVariants.root({
+      appearance: undefined,
+    });
+    expect(root).not.toContain("undefined");
+    // The runtime also drops null values defensively (see `isRecord`/cleanedProps
+    // guard), even though the typed bag does not permit null for `isDisabled`.
+    const loose = buttonVariants.root({
+      isDisabled: null,
+    } as Record<string, unknown>);
+    expect(loose).not.toContain("null");
+  });
+});

--- a/packages/core/tests/configs/v2-safelist.test.ts
+++ b/packages/core/tests/configs/v2-safelist.test.ts
@@ -51,6 +51,23 @@ describe("v2 compat: generateSafeList", () => {
     expect(safelist).toContain("md:shadow");
   });
 
+  it("does not throw when a component declares responsiveVariants but no variants", () => {
+    // v2 `variants` is optional. A component can list `responsiveVariants`
+    // while omitting `variants`; generateSafeList must not dereference an
+    // undefined variants map. (Built raw since the types forbid this shape.)
+    const optionsWithoutVariants = {
+      options: {
+        slots: { root: "block" },
+        compoundVariants: [],
+        defaultVariants: {},
+        responsiveVariants: ["size"],
+      },
+    };
+    expect(() =>
+      generateSafeList([optionsWithoutVariants], ["sm", "md"])
+    ).not.toThrow();
+  });
+
   it("works with the v3 `compose` result shape too (mixed consumers)", () => {
     const card = composeV3<{
       slots: ["root"];

--- a/packages/core/tests/configs/v2-safelist.test.ts
+++ b/packages/core/tests/configs/v2-safelist.test.ts
@@ -26,8 +26,8 @@ const makeBadge = () =>
     compoundVariants: [
       {
         conditions: { size: "md" },
-        // v2 `class:` spelling — must end up in the safelist.
-        class: { root: "ring-2" },
+        // v2 `class:` spelling with per-slot arrays — must end up in the safelist.
+        class: { root: ["ring-2", "shadow"] },
       },
     ],
     defaultVariants: { size: "sm" },
@@ -47,6 +47,8 @@ describe("v2 compat: generateSafeList", () => {
     // expanded across screens too.
     expect(safelist).toContain("sm:ring-2");
     expect(safelist).toContain("md:ring-2");
+    expect(safelist).toContain("sm:shadow");
+    expect(safelist).toContain("md:shadow");
   });
 
   it("works with the v3 `compose` result shape too (mixed consumers)", () => {

--- a/packages/core/tests/configs/v2-safelist.test.ts
+++ b/packages/core/tests/configs/v2-safelist.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { compose as composeV3, setupCompose } from "../../src/tailwind-buddy";
+import { generateSafeList } from "../../src/utils/tailwind-utils";
+
+const compose = setupCompose(["sm", "md"] as const, (s) => s);
+
+/**
+ * `generateSafeList` reads `.options` and internally normalises `classes`→`class`
+ * via `cleanCompoundClasses`. Because `setupCompose` already normalises
+ * `class`→`classes` on `.options`, a v2 `class:` compound is safelisted correctly
+ * — guarding against the unpatched-v3 regression where `class:` compounds were
+ * silently dropped.
+ *
+ * Each test builds a fresh instance because `generateSafeList` mutates the
+ * `options.compoundVariants` of its argument (pre-existing v3 behaviour).
+ */
+const makeBadge = () =>
+  compose({
+    slots: { root: "inline-flex" },
+    variants: {
+      size: {
+        sm: { root: "p-1" },
+        md: { root: "p-2" },
+      },
+    },
+    compoundVariants: [
+      {
+        conditions: { size: "md" },
+        // v2 `class:` spelling — must end up in the safelist.
+        class: { root: "ring-2" },
+      },
+    ],
+    defaultVariants: { size: "sm" },
+    responsiveVariants: ["size"],
+  })();
+
+describe("v2 compat: generateSafeList", () => {
+  it("safelists responsive variant classes", () => {
+    const safelist = generateSafeList([makeBadge()], ["sm", "md"]);
+    expect(safelist).toContain("sm:p-1");
+    expect(safelist).toContain("md:p-2");
+  });
+
+  it("safelists `class:` compound classes (regression guard)", () => {
+    const safelist = generateSafeList([makeBadge()], ["sm", "md"]);
+    // The compound matches responsive variant `size`, so its classes are
+    // expanded across screens too.
+    expect(safelist).toContain("sm:ring-2");
+    expect(safelist).toContain("md:ring-2");
+  });
+
+  it("works with the v3 `compose` result shape too (mixed consumers)", () => {
+    const card = composeV3<{
+      slots: ["root"];
+      variants: { size: ["sm", "md"] };
+      props: {};
+      screens: ["sm", "md"];
+    }>({
+      slots: { root: "block" },
+      variants: { size: { sm: "p-1", md: "p-2" } },
+      defaultVariants: { size: "sm" },
+      responsiveVariants: ["size"],
+    });
+    const safelist = generateSafeList([card], ["sm", "md"]);
+    expect(safelist).toContain("sm:p-1");
+    expect(safelist).toContain("md:p-2");
+  });
+});

--- a/packages/core/tests/setup/v2-compat.ts
+++ b/packages/core/tests/setup/v2-compat.ts
@@ -1,0 +1,105 @@
+import { setupCompose, VariantsProps } from "../../src/tailwind-buddy";
+
+/**
+ * Mirrors a v2 consumer's `tailwind-buddy-interface.ts`:
+ * a `setupCompose` factory bound to custom screens and a class-merging function.
+ */
+
+export type Screens = "sm" | "md" | "lg" | "xl";
+export const screens: Screens[] = ["sm", "md", "lg", "xl"];
+
+/** Minimal tailwind-merge stand-in: last conflicting utility wins. */
+export const mergeClasses = (input: string): string => {
+  const tokens = input.split(" ").filter(Boolean);
+  const seen = new Map<string, string>();
+  for (const token of tokens) {
+    // group key = the utility prefix (e.g. "p" for "p-1", "p-2")
+    const match = token.match(/^([a-z]+)-/);
+    const key = match ? match[1] : token;
+    seen.set(key, token);
+  }
+  return [...seen.values()].join(" ");
+};
+
+export const compose = setupCompose<Screens>(screens, mergeClasses);
+
+/* -------------------------------------------------------------------------- */
+/* A representative component built exactly like a v2 consumer's variant file:*/
+/* - curried `<ButtonBaseProps>()`                                             */
+/* - `class:` (singular) compound variants                                    */
+/* - `responsiveVariants`                                                      */
+/* - `VariantsProps<typeof x>` inferred (no manual variant re-declaration)     */
+/* -------------------------------------------------------------------------- */
+
+export interface ButtonBaseProps {
+  isDisabled?: boolean;
+  isDisabledFocusable?: boolean;
+  enableGroupHover?: boolean;
+}
+
+export const buttonVariants = compose({
+  slots: {
+    root: "inline-flex items-center justify-center",
+    label: "font-bold",
+    icon: "shrink-0",
+  },
+  variants: {
+    appearance: {
+      default: {},
+      primary: {
+        root: "bg-blue-500",
+        icon: "text-white",
+      },
+      destructive: {
+        root: "bg-red-500",
+      },
+    },
+    size: {
+      xs: { root: "p-1", label: "text-xs" },
+      sm: { root: "p-2", label: "text-sm" },
+      md: { root: "p-3", label: "text-base" },
+      lg: { root: "p-4", label: "text-lg" },
+    },
+    variant: {
+      contained: "",
+      text: "",
+    },
+  },
+  compoundVariants: [
+    // v2 `class:` (singular) spelling — must still apply.
+    {
+      conditions: {
+        appearance: "primary",
+        variant: "contained",
+        isDisabled: false,
+        isDisabledFocusable: false,
+      },
+      class: {
+        root: "hover:bg-blue-600",
+        icon: "group-hover:text-blue-200",
+      },
+    },
+    {
+      conditions: { variant: "contained", isDisabled: true },
+      class: {
+        root: "bg-gray-300 text-gray-400",
+        icon: "text-gray-400",
+      },
+    },
+    // v3 `classes:` (plural) spelling must also work.
+    {
+      conditions: { appearance: "destructive", variant: "contained" },
+      classes: {
+        root: "hover:bg-red-600",
+      },
+    },
+  ],
+  defaultVariants: {
+    appearance: "default",
+    size: "md",
+    variant: "contained",
+  },
+  responsiveVariants: ["size"],
+})<ButtonBaseProps>();
+
+export type ButtonProps = VariantsProps<typeof buttonVariants> & ButtonBaseProps;

--- a/packages/core/tests/types/v2-compat.test-d.ts
+++ b/packages/core/tests/types/v2-compat.test-d.ts
@@ -1,0 +1,73 @@
+/**
+ * Type-level proof that the v2 compat surface matches a v2 consumer's usage.
+ * This file is type-checked via `pnpm typecheck:tests` (not executed at runtime).
+ *
+ * v2 `setupCompose` infers variant *keys* from the `variants` object literal so
+ * consumers never re-declare them (resolves issue #31). As in v2, the inferred
+ * variant *values* are intentionally loose (`string | number`) — that is the
+ * behaviour existing v2 consumers were built against, so preserving it means zero migration.
+ */
+import { expectTypeOf } from "vitest";
+import type { ButtonProps } from "../setup/v2-compat";
+import { buttonVariants } from "../setup/v2-compat";
+
+// 1. Slot functions are exposed at the top level (v2 destructuring pattern).
+const { root, label, icon } = buttonVariants;
+expectTypeOf(root).toEqualTypeOf<(props?: ButtonProps) => string>();
+expectTypeOf(label).toEqualTypeOf<(props?: ButtonProps) => string>();
+expectTypeOf(icon).toEqualTypeOf<(props?: ButtonProps) => string>();
+
+// 2. `definition()` exposes defaults & variants for introspection (storybook).
+const defaultVariants = buttonVariants.definition().defaultVariants;
+// Non-optional (required) so `.appearance` / `.size` / `.variant` need no null guard.
+expectTypeOf(defaultVariants).not.toBeUndefined();
+expectTypeOf(defaultVariants).toHaveProperty("appearance");
+expectTypeOf(defaultVariants).toHaveProperty("size");
+expectTypeOf(defaultVariants).toHaveProperty("variant");
+
+const variants = buttonVariants.definition().variants;
+expectTypeOf(variants).toMatchTypeOf<Record<string, unknown> | undefined>();
+
+// 3. `options` is present for `generateSafeList`.
+expectTypeOf(buttonVariants.options).toMatchTypeOf<Record<string, unknown>>();
+
+// 4. `VariantsProps<typeof buttonVariants>` is inferred WITHOUT re-declaring the
+//    variant keys (issue #31): the bag carries every declared variant key plus
+//    the base props, all optional.
+expectTypeOf<ButtonProps>().toMatchTypeOf<{
+  appearance?: string | number;
+  size?:
+    | string
+    | number
+    | { initial: string | number }
+    | { sm?: string | number }
+    | { md?: string | number }
+    | { lg?: string | number }
+    | { xl?: string | number };
+  variant?: string | number;
+  isDisabled?: boolean;
+  isDisabledFocusable?: boolean;
+  enableGroupHover?: boolean;
+  className?: string;
+  class?: string;
+}>();
+
+// 5. The base props flow through (intersection).
+expectTypeOf<ButtonProps>().toMatchTypeOf<{ isDisabled?: boolean }>();
+
+// 6. `size` is responsive (listed in responsiveVariants) — accepts an object.
+expectTypeOf<ButtonProps["size"]>().toMatchTypeOf<
+  | string
+  | number
+  | { initial: string | number }
+  | undefined
+>();
+
+// 7. Slot calls accept the inferred bag.
+expectTypeOf(root).toBeCallableWith({
+  appearance: "primary",
+  size: { initial: "md", lg: "lg" },
+  variant: "contained",
+  isDisabled: false,
+  className: "extra",
+});

--- a/packages/core/tests/types/v2-compat.test-d.ts
+++ b/packages/core/tests/types/v2-compat.test-d.ts
@@ -8,6 +8,7 @@
  * behaviour existing v2 consumers were built against, so preserving it means zero migration.
  */
 import { expectTypeOf } from "vitest";
+import { setupCompose } from "../../src/tailwind-buddy";
 import type { ButtonProps } from "../setup/v2-compat";
 import { buttonVariants } from "../setup/v2-compat";
 
@@ -71,3 +72,10 @@ expectTypeOf(root).toBeCallableWith({
   isDisabled: false,
   className: "extra",
 });
+
+// 8. Slot-only configs keep consumer props assignable when `variants` is omitted.
+const slotOnlyVariants = setupCompose(["md"] as const)({
+  slots: { root: "x" },
+  defaultVariants: {},
+})<{ disabled?: boolean }>();
+slotOnlyVariants.root({ disabled: true });

--- a/packages/core/tsconfig.tests.json
+++ b/packages/core/tsconfig.tests.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "compilerOptions": {
+    "types": ["vitest"],
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
## Overview

Resolves #31

v3's breaking changes force a large migration for v2 consumers, including two **silent runtime regressions** (not type errors):

1. **tailwind-merge dropped.** v3 only dedupes via `Set`, so conflicting utilities (`p-1 p-4` to `p-4`) stop resolving, a visual regression on every component.
2. **`class:` compounds silently no-op.** v3 reads `cv.classes` (plural); v2 wrote `class:` (singular). No error, just missing classes.

This PR restores the v2 API as a thin adapter over the existing v3 runtime. v2 call sites compile and behave unchanged; v3 `compose` / `VariantProps` stays for new consumers. Migration collapses to a version bump.

### Restored v2 surface

| v2 API | this PR |
|---|---|
| `setupCompose(screens, mergeClasses)` | restored (custom screens + class-merge hook) |
| `compose(config)<Props>()` curried | curry preserved |
| `VariantsProps<typeof x>` inferred | inference preserved (#31) |
| `class:` in compoundVariants | `class:` + `classes:` both accepted |
| top-level slot fns + `.definition()` | both returned |
| `responsiveVariants`, custom screens | preserved |

### Issue #31

`VariantsProps<typeof x>` infers variant keys from the `variants` literal, so no re-declaration. `variants` / `compoundVariants` optional; `responsiveVariants` defaults to scalar.

### Implementation

- Single shared runtime (`createSlotsCore`) feeds both `compose` (v3) and `setupCompose` (v2). Hot path (cache hit) identical; only difference is `mergeClasses` on cache misses, which v2 consumers already pay.
- `class` normalised to `classes` once at setup, so the core and `generateSafeList` always read `classes`.

### Tests

Full workspace verified (core, ui, sandbox, benchmark, vuelib, vuelib-tailwind4 all build/typecheck clean). Core: **49 tests passing** + type test (`tsc -p tsconfig.tests.json`, now run by `test:ci`). Verified against a large private v2 consumer: `tsc --noEmit` 0 errors on both `2.4.3` and this PR.

### Benchmarks

`node benchmark.mjs`, ops/sec vs v3.1.3:

| Scenario | before | after |
|---|---|---|
| v3 compose, no twMerge | 4,358,578 | ~4,245,000 (noise) |
| v3 compose + external twMerge | 3,990,691 | ~4,065,000 |
| v2 setupCompose, twMerge injected | n/a | ~4,527,000 |

v3 unchanged within noise; v2 injected merge fastest (runs only on cache misses).
