### PR TITLE
Replace clsx + tailwind-merge with cnfast (cn helper)

### DIFF
--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -12,6 +12,19 @@ inside core folder:
 come back to benchmark folder and run
 `node benchmarks.mjs`
 
+## `cn` helper benchmark (`cn-benchmark.mjs`)
+
+Measures the `cn` utility that consumers use to merge classes, comparing the
+legacy `clsx` + `tailwind-merge` implementation against the drop-in `cnfast`.
+
+Workloads are harvested from real call sites in this repo (vuelib Button
+variants + the shadcn-style override pattern). A parity guard asserts
+byte-identical output before every run.
+
+Run it from the benchmark folder:
+
+`node cn-benchmark.mjs`
+
 ## Test
 
 `pnpm test`

--- a/packages/benchmark/cn-benchmark.mjs
+++ b/packages/benchmark/cn-benchmark.mjs
@@ -1,0 +1,121 @@
+// Before/after benchmark for the `cn` helper.
+//
+//   before: clsx + tailwind-merge   ->  twMerge(clsx(inputs))
+//   after:  cnfast                  ->  export { cn } from "cnfast"
+//
+// Workloads are harvested from real call sites in this repo (vuelib / vuelib-tailwind4
+// Button variants + the shadcn-style override pattern) so the numbers reflect actual
+// per-render cost, not synthetic strings.
+import Benchmark from "benchmark";
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+import { cn as cnFast } from "cnfast";
+
+// --- before: the exact implementation currently in packages/*/src/lib/utils.ts ---
+const legacyCn = (...inputs) => twMerge(clsx(inputs));
+
+// --- workloads (args pre-built so we only measure the cn call itself) ---
+const isActive = true;
+const isLarge = true;
+
+const workloads = {
+  // vuelib CustomButton.vue: cn(root({ appearance, isDisabled, size, variant }))
+  // root() default output contains duplicated bg-red-500 (slot + variant + compound).
+  "single string (vuelib root)": [
+    "bg-red-500 bg-red-500 w-[100px] h-[100px] bg-red-500",
+  ],
+
+  // slot output + consumer className override with conflicts (bg / width / radius).
+  "override (slot + className)": [
+    "bg-red-500 w-[100px] h-[100px] rounded-md font-medium",
+    "bg-blue-500 w-[200px] rounded-lg",
+  ],
+
+  // shadcn-style: strings + boolean + object + falsy values + undefined/null.
+  "shadcn mixed (strings+obj+bool)": [
+    "px-2 py-1 text-sm bg-red-500 rounded-md font-medium",
+    "px-4 bg-blue-500",
+    { "text-lg": isLarge, "font-bold": false, "text-white": true },
+    isActive && "rounded-lg",
+    undefined,
+    null,
+  ],
+
+  // larger realistic component: ~20 base classes + a heavy override set.
+  "large component (20+ classes)": [
+    "flex items-center justify-between gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white rounded-lg border border-gray-200 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors",
+    "px-6 py-3 text-base font-bold text-white bg-blue-600 rounded-xl border-transparent shadow-md hover:bg-blue-700",
+    { "disabled:opacity-50": true, "cursor-pointer": isActive },
+  ],
+};
+
+// --- parity: cnfast must be byte-identical to legacy (per cnfast's promise) ---
+let parityFailures = 0;
+for (const [name, args] of Object.entries(workloads)) {
+  const a = legacyCn(...args);
+  const b = cnFast(...args);
+  if (a !== b) {
+    parityFailures++;
+    console.error(`[PARITY FAIL] ${name}\n  legacy : ${JSON.stringify(a)}\n  cnfast : ${JSON.stringify(b)}`);
+  }
+}
+if (parityFailures > 0) {
+  console.error(`\n${parityFailures} workload(s) produced different output. Aborting benchmark.`);
+  process.exit(1);
+}
+console.log(`\n[PARITY OK] all ${Object.keys(workloads).length} workloads byte-identical between legacy and cnfast\n`);
+
+// --- benchmark ---
+const suite = new Benchmark.Suite();
+
+for (const [name, args] of Object.entries(workloads)) {
+  suite.add(`BEFORE (clsx+twMerge) | ${name}`, function () {
+    legacyCn(...args);
+  });
+  suite.add(`AFTER  (cnfast)       | ${name}`, function () {
+    cnFast(...args);
+  });
+}
+
+const results = [];
+
+suite
+  .on("cycle", function (event) {
+    const t = event.target;
+    results.push({ name: t.name, hz: t.hz, rme: t.stats.rme, samples: t.stats.sample.length });
+    console.log(String(t));
+  })
+  .on("complete", function () {
+    console.log("\n--- summary (ops/sec, higher = faster) ---");
+    // group by workload and compute speedup
+    const byWorkload = {};
+    for (const r of results) {
+      const sep = r.name.indexOf("|");
+      const impl = r.name.slice(0, sep).trim();
+      const workload = r.name.slice(sep + 1).trim();
+      const key = impl.startsWith("BEFORE") ? "before" : "after";
+      (byWorkload[workload] ??= {})[key] = r;
+    }
+    console.log(
+      "workload".padEnd(28) +
+        "before ops/sec".padStart(18) +
+        "after ops/sec".padStart(18) +
+        "speedup".padStart(12),
+    );
+    for (const [w, g] of Object.entries(byWorkload)) {
+      const before = g.before;
+      const after = g.after;
+      const speedup = after.hz / before.hz;
+      console.log(
+        w.padEnd(28) +
+          fmt(before).padStart(18) +
+          fmt(after).padStart(18) +
+          `${speedup.toFixed(2)}x`.padStart(12),
+      );
+    }
+  })
+  .run({ async: true });
+
+function fmt(r) {
+  return `${(r.hz).toLocaleString("en-US", { maximumFractionDigits: 0 })} ±${r.rme.toFixed(2)}%`;
+}

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -14,6 +14,8 @@
     "@busbud/tailwind-buddy": "workspace:*",
     "benchmark": "^2.1.4",
     "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "cnfast": "^0.0.8",
     "tailwind-merge": "^2.3.0",
     "tailwind-variants": "^0.2.1",
     "vitest": "^1.6.0"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,10 +29,9 @@
     "./style.css": "./dist/style.css"
   },
   "dependencies": {
-    "clsx": "^2.1.1",
+    "cnfast": "^0.0.8",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "tailwind-merge": "^2.3.0"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.2",

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react";
 import { type ButtonProps, buttonVariants } from "./Button.variants";
-import { twMerge } from "tailwind-merge"
+import { cn } from "cnfast"
 
 const defaultVariants = buttonVariants.options.defaultVariants;
 
@@ -32,7 +32,7 @@ export const Button: React.FC<ButtonProps> = ({
 
   return (
     <button
-      className={twMerge(root({
+      className={cn(root({
         appearance,
         className,
         size,

--- a/packages/vuelib-tailwind4/package.json
+++ b/packages/vuelib-tailwind4/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.0.8",
     "@types/node": "^22.13.5",
-    "clsx": "^2.1.1",
+    "cnfast": "^0.0.8",
     "tailwindcss": "^4.0.8",
     "vue": "^3.5.13"
   },
@@ -21,7 +21,6 @@
     "@busbud/tailwind-buddy": "workspace:*",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vue/tsconfig": "^0.7.0",
-    "tailwind-merge": "^2.5.2",
     "tsx": "^4.19.3",
     "typescript": "~5.7.3",
     "vite": "^6.1.0",

--- a/packages/vuelib-tailwind4/src/lib/utils.ts
+++ b/packages/vuelib-tailwind4/src/lib/utils.ts
@@ -1,6 +1,1 @@
-import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from "cnfast";

--- a/packages/vuelib/package.json
+++ b/packages/vuelib/package.json
@@ -11,9 +11,8 @@
   "dependencies": {
     "@busbud/tailwind-buddy": "workspace:*",
     "autoprefixer": "^10.4.19",
-    "clsx": "^2.1.1",
+    "cnfast": "^0.0.8",
     "postcss": "^8.4.38",
-    "tailwind-merge": "^3.0.2",
     "tailwindcss": "3",
     "vue": "^3.5.13"
   },

--- a/packages/vuelib/src/lib/utils.ts
+++ b/packages/vuelib/src/lib/utils.ts
@@ -1,6 +1,1 @@
-import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from "cnfast";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,9 +212,9 @@ importers:
       '@types/node':
         specifier: ^22.13.5
         version: 22.13.5
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cnfast:
+        specifier: ^0.0.8
+        version: 0.0.8
       tailwindcss:
         specifier: ^4.0.8
         version: 4.0.9
@@ -231,9 +231,6 @@ importers:
       '@vue/tsconfig':
         specifier: ^0.7.0
         version: 0.7.0(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))
-      tailwind-merge:
-        specifier: ^2.5.2
-        version: 2.6.0
       tsx:
         specifier: ^4.19.3
         version: 4.19.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,15 +175,12 @@ importers:
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.20(postcss@8.5.3)
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cnfast:
+        specifier: ^0.0.8
+        version: 0.0.8
       postcss:
         specifier: ^8.4.38
         version: 8.5.3
-      tailwind-merge:
-        specifier: ^3.0.2
-        version: 3.0.2
       tailwindcss:
         specifier: '3'
         version: 3.4.17
@@ -3184,9 +3181,6 @@ packages:
 
   tailwind-merge@2.6.0:
     resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
-
-  tailwind-merge@3.0.2:
-    resolution: {integrity: sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==}
 
   tailwind-variants@0.2.1:
     resolution: {integrity: sha512-2xmhAf4UIc3PijOUcJPA1LP4AbxhpcHuHM2C26xM0k81r0maAO6uoUSHl3APmvHZcY5cZCY/bYuJdfFa4eGoaw==}
@@ -6556,8 +6550,6 @@ snapshots:
   tabbable@6.2.0: {}
 
   tailwind-merge@2.6.0: {}
-
-  tailwind-merge@3.0.2: {}
 
   tailwind-variants@0.2.1(tailwindcss@4.0.9):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      cnfast:
+        specifier: ^0.0.8
+        version: 0.0.8
       tailwind-merge:
         specifier: ^2.3.0
         version: 2.6.0
@@ -1653,6 +1659,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cnfast@0.0.8:
+    resolution: {integrity: sha512-EjXKMfGfdwtV4AcNSQ6AwQaVzpC1B7IxeiwA3FlhTXz+YFlMKVi4c1JX9tgD2QOlahQXjB8KUXrBaYG+3v871Q==}
+    hasBin: true
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -5058,6 +5068,8 @@ snapshots:
   clone@1.0.4: {}
 
   clsx@2.1.1: {}
+
+  cnfast@0.0.8: {}
 
   color-convert@1.9.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,18 +117,15 @@ importers:
 
   packages/ui:
     dependencies:
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cnfast:
+        specifier: ^0.0.8
+        version: 0.0.8
       react:
         specifier: ^18.2.0
         version: 18.3.1
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
-      tailwind-merge:
-        specifier: ^2.3.0
-        version: 2.6.0
     devDependencies:
       '@busbud/tailwind-buddy':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Replace the `cn` helper (`clsx` + `tailwind-merge`) with [`cnfast`](https://github.com/aidenybai/cnfast) across the consumer packages (`vuelib`, `vuelib-tailwind4`, `ui`), and add a before/after benchmark.

cnfast is a drop-in replacement for the shadcn-style `cn` utility. It produces **byte-identical output** to `twMerge(clsx(...))` while running faster — especially on the hot paths used in this repo.

> **Note: this PR is stacked on `feat/v2-compat-adapter`.** The branch was cut from that feature branch, so the base is `feat/v2-compat-adapter` (not `main`) to keep this PR focused on the 4 cnfast commits. If you'd prefer it retargeted to `main`, say the word.

## Benchmark (`packages/benchmark/cn-benchmark.mjs`)

Head-to-head `cn` benchmark with a parity guard that asserts byte-identical output before every run. Workloads are harvested from real call sites in this repo (vuelib Button variants + shadcn-style override pattern). Node 22, ops/sec higher = faster.

| workload | before (clsx+twMerge) | after (cnfast) | speedup |
|---|---|---|---|
| single string (vuelib `root()`) | ~25M | ~52M | **~2.1x** |
| override (slot + className) | ~3.8M | ~25M | **~6.5x** |
| shadcn mixed (strings+obj+bool) | ~2.3M | ~3.0M | **~1.3x** |
| large component (20+ classes) | ~1.17M | ~1.23M | **~1.08x** |

The biggest wins land on the actual hot paths: the single-string `cn(root({...}))` used by both `CustomButton.vue` files (~2x) and the slot+override pattern (~6.5x).

The existing `benchmark.mjs` measures the variant-composition factories (`compose` vs `cva` vs `tv`); the new `cn-benchmark.mjs` measures a different concern (the `cn` utility itself), so it ships as a separate file and is documented in the package README.

## Changes (one commit per package)

- **`test(benchmark)`** — add `cn-benchmark.mjs` (parity guard + head-to-head suite) + benchmark deps (`cnfast`, `clsx` needed to measure the "before" side) + README docs.
- **`refactor(vuelib)`** — `utils.ts` → `export { cn } from "cnfast"`; drop `clsx` + `tailwind-merge`. Removes `tailwind-merge@3.0.2` from the lockfile (only consumer of v3).
- **`refactor(vuelib-tailwind4)`** — same swap; drop `clsx` (dep) + `tailwind-merge` (devDep). `tailwind-merge@2.6.0` retained (benchmark + tailwind-variants still use it).
- **`refactor(ui)`** — `Button.tsx` used `twMerge` directly on a single slot string; swapped to `cn` from `cnfast` (byte-identical for a single string). `clsx` was an unused dep; both it and `tailwind-merge` are dropped.

## Verification

- `pnpm install --frozen-lockfile` passes at **every commit** (bisectable — verified by checking out each commit).
- Builds green: `vuelib`, `vuelib-tailwind4`, `ui` (typecheck + vite build).
- `packages/benchmark` existing `validate.test.mjs` → 2/2 pass.
- `cn-benchmark.mjs` → parity OK on all workloads, cnfast wins every workload.
- No `clsx`/`tailwind-merge`/`twMerge` references remain in the three converted `src/` dirs.

## Caveats

- cnfast is at `0.0.8` (pre-1.0). Pinned `^0.0.8`; you may want an exact pin or a Renovate gate before shipping given the early version.
- The core library's own pluggable merge fn (`setupCompose(..., twMerge)`) is untouched — that's a different, intentionally-pluggable concern. Doc examples still reference `tailwind-merge` for that path; happy to swap those too if desired.
